### PR TITLE
add llm as judge

### DIFF
--- a/benchmark/evaluate.py
+++ b/benchmark/evaluate.py
@@ -8,10 +8,16 @@ Benchmark 评估脚本 —— 对比生成答案与标准答案
 用法:
   python -m benchmark.evaluate benchmark_results.json
   python -m benchmark.evaluate benchmark_results.json --output eval_report.json
+
+可选:
+  --golden  额外计算 golden 指标:
+            - semantic_similarity (embedding cosine similarity)
+            - factual_correctness_f1 (claim-based NLI)
 """
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections import Counter
@@ -51,11 +57,76 @@ def token_f1(prediction: str, reference: str) -> float:
     return 2 * precision * recall / (precision + recall)
 
 
-def evaluate(results: list[dict]) -> dict:
+def _load_env_file(env_path: str) -> None:
+    if not os.path.exists(env_path):
+        return
+    with open(env_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k and k not in os.environ:
+                os.environ[k] = v
+
+
+def _read_datamind_env() -> dict[str, str | None]:
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env_path = os.path.join(repo_root, "DataMind", ".env")
+    _load_env_file(env_path)
+    return {
+        "llm_model": os.getenv("LLM_MODEL"),
+        "llm_api_key": os.getenv("LLM_API_KEY"),
+        "llm_api_base": os.getenv("LLM_API_BASE") or None,
+        "embedding_model": os.getenv("EMBEDDING_MODEL"),
+        "embedding_api_key": os.getenv("EMBEDDING_API_KEY"),
+        "embedding_api_base": os.getenv("EMBEDDING_API_BASE") or None,
+    }
+
+
+
+
+
+def evaluate(results: list[dict], include_golden: bool = False) -> dict:
     """对结果列表做评估，返回汇总 + 逐条明细。"""
+    semantic_metric = None
+    factual_metric = None
+    if include_golden:
+        env = _read_datamind_env()
+        if not env.get("llm_api_key") or not env.get("embedding_api_key"):
+            raise ValueError("Missing LLM_API_KEY or EMBEDDING_API_KEY in environment/.env")
+
+        from benchmark.metrics.golden_answer_metrics import (
+            FactualCorrectnessMetric,
+            SemanticSimilarityMetric,
+        )
+        from benchmark.models.embedding_models import OpenAIEmbeddingModel
+        from benchmark.models.llm_judges import OpenAIModel
+
+        llm_model = OpenAIModel(
+            model_options={
+                "name": env.get("llm_model") or "gpt-4o-mini",
+                "api_key": env["llm_api_key"],
+                "base_url": env["llm_api_base"],
+            }
+        )
+        embedding_model = OpenAIEmbeddingModel(
+            model_options={
+                "name": env.get("embedding_model") or "text-embedding-3-small",
+                "api_key": env["embedding_api_key"],
+                "base_url": env["embedding_api_base"],
+            }
+        )
+        semantic_metric = SemanticSimilarityMetric(embedding_model)
+        factual_metric = FactualCorrectnessMetric(llm_model)
+
     evaluated = []
     em_correct = 0
     f1_sum = 0.0
+    semantic_sum = 0.0
+    factual_sum = 0.0
     total = 0
 
     for r in results:
@@ -70,7 +141,7 @@ def evaluate(results: list[dict]) -> dict:
             em_correct += 1
         f1_sum += f1
 
-        evaluated.append({
+        item = {
             "index": r.get("index"),
             "question_id": r.get("question_id"),
             "question": r["question"],
@@ -78,7 +149,17 @@ def evaluate(results: list[dict]) -> dict:
             "reference_answer": ref,
             "exact_match": em,
             "f1": round(f1, 4),
-        })
+        }
+
+        if include_golden and semantic_metric is not None and factual_metric is not None:
+            semantic = float(semantic_metric.compute(r["question"], answer, ref).get("semantic_similarity", 0.0))
+            factual_f1 = float(factual_metric.compute(r["question"], answer, ref).get("factual_correctness_f1", 0.0))
+            item["semantic_similarity"] = round(semantic, 6)
+            item["factual_correctness_f1"] = round(factual_f1, 6)
+            semantic_sum += semantic
+            factual_sum += factual_f1
+
+        evaluated.append(item)
 
     summary = {
         "total": total,
@@ -86,6 +167,9 @@ def evaluate(results: list[dict]) -> dict:
         "exact_match_rate": round(em_correct / total, 4) if total else 0,
         "avg_f1": round(f1_sum / total, 4) if total else 0,
     }
+    if include_golden:
+        summary["semantic_similarity_avg"] = round(semantic_sum / total, 6) if total else 0.0
+        summary["factual_correctness_f1_avg"] = round(factual_sum / total, 6) if total else 0.0
     return {"summary": summary, "details": evaluated}
 
 
@@ -97,6 +181,10 @@ def _print_report(report: dict):
     print(f"  Total evaluated:   {s['total']}")
     print(f"  Exact Match:       {s['exact_match_count']}/{s['total']} ({s['exact_match_rate']*100:.1f}%)")
     print(f"  Avg Token-F1:      {s['avg_f1']:.4f}")
+    if "semantic_similarity_avg" in s:
+        print(f"  Semantic Sim:      {s['semantic_similarity_avg']:.6f}")
+    if "factual_correctness_f1_avg" in s:
+        print(f"  Factual F1:        {s['factual_correctness_f1_avg']:.6f}")
     print("=" * 55)
 
     details = report["details"]
@@ -115,6 +203,7 @@ def main():
     parser = argparse.ArgumentParser(description="DataMind Benchmark Evaluator")
     parser.add_argument("results", help="benchmark runner 输出的 JSON 文件路径")
     parser.add_argument("--output", default=None, help="评估报告输出路径 (JSON)")
+    parser.add_argument("--golden", action="store_true", help="额外计算 golden 指标 (semantic similarity + factual correctness)")
     args = parser.parse_args()
 
     with open(args.results, "r", encoding="utf-8") as f:
@@ -126,7 +215,7 @@ def main():
         print("        请确认问题集 JSONL 包含 reference_answer，并使用新版 benchmark runner 重跑。")
         sys.exit(1)
 
-    report = evaluate(results)
+    report = evaluate(results, include_golden=args.golden)
     _print_report(report)
 
     out_path = args.output or args.results.replace(".json", "_eval.json")

--- a/benchmark/metrics/golden_answer_metrics.py
+++ b/benchmark/metrics/golden_answer_metrics.py
@@ -1,0 +1,279 @@
+"""Golden answer evaluation metrics for comparing generated answers against reference answers.
+
+Implements golden answer metrics:
+- Semantic Similarity: Direct embedding similarity
+- Factual Correctness: Claim-based NLI with precision/recall/F1
+"""
+
+from typing import Any, Dict, List
+from enum import Enum
+import logging
+
+import numpy as np
+from pydantic import BaseModel
+
+from open_rag_eval.metrics.base_metrics import GoldenAnswerMetric
+from open_rag_eval.models.embedding_models import EmbeddingModel
+from open_rag_eval.models.llm_judges import LLMJudgeModel
+
+
+logger = logging.getLogger(__name__)
+
+
+# ============ Utility Functions ============
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute cosine similarity between two vectors.
+
+    Args:
+        a: First vector
+        b: Second vector
+
+    Returns:
+        Cosine similarity score (float between -1 and 1)
+    """
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(np.dot(a, b) / (norm_a * norm_b))
+
+
+# ============ Pydantic Models for Structured Output ============
+
+class Claims(BaseModel):
+    """Container for claims extracted from text."""
+    claims: List[str]
+
+
+class NLIVerdict(str, Enum):
+    """NLI verdict types."""
+    ENTAILMENT = "entailment"
+    CONTRADICTION = "contradiction"
+    NEUTRAL = "neutral"
+
+
+class ClaimVerdict(BaseModel):
+    """NLI verdict for a single claim."""
+    claim: str
+    verdict: NLIVerdict
+
+
+class ClaimVerdicts(BaseModel):
+    """Container for NLI verdicts on multiple claims."""
+    verdicts: List[ClaimVerdict]
+
+
+# ============ Metric Implementations ============
+
+class SemanticSimilarityMetric(GoldenAnswerMetric):
+    """Direct semantic similarity between generated and golden answers.
+
+    Uses embedding cosine similarity to measure how semantically similar
+    the generated answer is to the expected golden answer.
+    """
+
+    def __init__(self, embedding_model: EmbeddingModel):
+        """Initialize Semantic Similarity metric.
+
+        Args:
+            embedding_model: Model for computing embeddings
+        """
+        self.embedding_model = embedding_model
+
+    @property
+    def name(self) -> str:
+        return "semantic_similarity"
+
+    def compute(
+        self,
+        query: str,
+        generated_answer: str,
+        expected_answer: str
+    ) -> Dict[str, float]:
+        """Compute semantic similarity between generated and expected answers.
+
+        Returns:
+            Dict with 'semantic_similarity' score
+        """
+        try:
+            # Embed both answers
+            embeddings = self.embedding_model.embed([generated_answer, expected_answer])
+            gen_embedding = embeddings[0]
+            exp_embedding = embeddings[1]
+
+            # Compute cosine similarity
+            similarity = cosine_similarity(gen_embedding, exp_embedding)
+
+            return {"semantic_similarity": similarity}
+
+        except Exception as e:
+            logger.error("Failed to compute semantic similarity: %s", e)
+            return {"semantic_similarity": 0.0}
+
+
+class FactualCorrectnessMetric(GoldenAnswerMetric):
+    """Factual correctness via claim-based NLI.
+
+    1. Decompose both answers into atomic claims
+    2. Use NLI to check:
+       - Precision: How many generated claims are entailed by golden answer
+       - Recall: How many golden claims are entailed by generated answer
+    3. Compute F1 score
+    """
+
+    _CLAIM_EXTRACTION_PROMPT = """Extract all atomic factual claims from the following text.
+Each claim should be a single, verifiable statement.
+Break down complex sentences into simple atomic claims.
+
+Text: {text}
+
+Extract all claims."""
+
+    _NLI_PROMPT = """For each claim below, determine if it is ENTAILED by, CONTRADICTED by, or NEUTRAL with respect to the reference text.
+
+Reference text: {reference}
+
+Claims to verify:
+{claims}
+
+For each claim, provide a verdict: "entailment" (claim is supported), "contradiction" (claim is contradicted), or "neutral" (claim cannot be verified from reference)."""
+
+    def __init__(self, llm_model: LLMJudgeModel):
+        """Initialize Factual Correctness metric.
+
+        Args:
+            llm_model: LLM for claim extraction and NLI
+        """
+        self.llm_model = llm_model
+        self.model_kwargs = {"temperature": 0.0}
+        # Token tracking
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+    @property
+    def name(self) -> str:
+        return "factual_correctness"
+
+    def compute(
+        self,
+        query: str,
+        generated_answer: str,
+        expected_answer: str
+    ) -> Dict[str, Any]:
+        """Compute factual correctness metrics.
+
+        Returns:
+            Dict with precision, recall, f1 scores and token_usage
+        """
+        # Reset token counters for this computation
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+        try:
+            # Extract claims from both answers
+            generated_claims = self._extract_claims(generated_answer)
+            expected_claims = self._extract_claims(expected_answer)
+
+            if not generated_claims or not expected_claims:
+                return {
+                    "factual_correctness_precision": 0.0,
+                    "factual_correctness_recall": 0.0,
+                    "factual_correctness_f1": 0.0,
+                    "generated_claims": generated_claims,
+                    "expected_claims": expected_claims,
+                    "token_usage": {
+                        "input_tokens": self._total_input_tokens,
+                        "output_tokens": self._total_output_tokens
+                    }
+                }
+
+            # Precision: generated claims verified against expected answer
+            precision_verdicts = self._verify_claims(generated_claims, expected_answer)
+            precision = self._compute_entailment_ratio(precision_verdicts)
+
+            # Recall: expected claims verified against generated answer
+            recall_verdicts = self._verify_claims(expected_claims, generated_answer)
+            recall = self._compute_entailment_ratio(recall_verdicts)
+
+            # F1 score
+            if precision + recall > 0:
+                f1 = 2 * precision * recall / (precision + recall)
+            else:
+                f1 = 0.0
+
+            return {
+                "factual_correctness_precision": precision,
+                "factual_correctness_recall": recall,
+                "factual_correctness_f1": f1,
+                "generated_claims": generated_claims,
+                "expected_claims": expected_claims,
+                "precision_verdicts": [v.model_dump() for v in precision_verdicts],
+                "recall_verdicts": [v.model_dump() for v in recall_verdicts],
+                "token_usage": {
+                    "input_tokens": self._total_input_tokens,
+                    "output_tokens": self._total_output_tokens
+                }
+            }
+
+        except Exception as e:
+            logger.error("Failed to compute factual correctness: %s", e)
+            return {
+                "factual_correctness_precision": 0.0,
+                "factual_correctness_recall": 0.0,
+                "factual_correctness_f1": 0.0,
+                "token_usage": {
+                    "input_tokens": self._total_input_tokens,
+                    "output_tokens": self._total_output_tokens
+                }
+            }
+
+    def _extract_claims(self, text: str) -> List[str]:
+        """Extract atomic claims from text."""
+        prompt = self._CLAIM_EXTRACTION_PROMPT.format(text=text)
+
+        result = self.llm_model.parse(
+            prompt,
+            response_format=Claims,
+            model_kwargs=self.model_kwargs
+        )
+
+        # Track tokens
+        metadata = result.get("metadata", {})
+        self._total_input_tokens += metadata.get("input_tokens", 0)
+        self._total_output_tokens += metadata.get("output_tokens", 0)
+
+        return result["response"].claims
+
+    def _verify_claims(self, claims: List[str], reference: str) -> List[ClaimVerdict]:
+        """Verify claims against reference text using NLI."""
+        if not claims:
+            return []
+
+        claims_formatted = "\n".join([f"{i+1}. {c}" for i, c in enumerate(claims)])
+        prompt = self._NLI_PROMPT.format(
+            reference=reference,
+            claims=claims_formatted
+        )
+
+        result = self.llm_model.parse(
+            prompt,
+            response_format=ClaimVerdicts,
+            model_kwargs=self.model_kwargs
+        )
+
+        # Track tokens
+        metadata = result.get("metadata", {})
+        self._total_input_tokens += metadata.get("input_tokens", 0)
+        self._total_output_tokens += metadata.get("output_tokens", 0)
+
+        return result["response"].verdicts
+
+    @staticmethod
+    def _compute_entailment_ratio(verdicts: List[ClaimVerdict]) -> float:
+        """Compute ratio of entailed claims."""
+        if not verdicts:
+            return 0.0
+
+        entailed = sum(1 for v in verdicts if v.verdict == NLIVerdict.ENTAILMENT)
+        return entailed / len(verdicts)

--- a/benchmark/models/embedding_models.py
+++ b/benchmark/models/embedding_models.py
@@ -1,0 +1,81 @@
+"""Embedding model implementations for semantic similarity computations."""
+
+from abc import ABC, abstractmethod
+from typing import List
+import logging
+
+import numpy as np
+import openai
+
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingModel(ABC):
+    """Abstract base class for embedding models."""
+
+    @abstractmethod
+    def embed(self, texts: List[str]) -> np.ndarray:
+        """Generate embeddings for a list of texts.
+
+        Args:
+            texts: List of strings to embed
+
+        Returns:
+            numpy array of shape (len(texts), embedding_dim)
+        """
+        pass
+
+    @abstractmethod
+    def embed_single(self, text: str) -> np.ndarray:
+        """Generate embedding for a single text.
+
+        Args:
+            text: String to embed
+
+        Returns:
+            numpy array of shape (embedding_dim,)
+        """
+        pass
+
+
+class OpenAIEmbeddingModel(EmbeddingModel):
+    """OpenAI embedding model implementation."""
+
+    def __init__(self, model_options: dict):
+        """Initialize OpenAI embedding model.
+
+        Args:
+            model_options: Dict containing:
+                - name: Model name (e.g., "text-embedding-3-large")
+                - api_key: OpenAI API key
+                - base_url: Optional OpenAI-compatible API base URL
+        """
+        self.model_name = model_options["name"]
+        self.api_key = model_options["api_key"]
+        self.base_url = model_options.get("base_url", None)
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    def embed(self, texts: List[str]) -> np.ndarray:
+        """Batch embed multiple texts."""
+        if not texts:
+            return np.array([])
+
+        # OpenAI API limits batch size, handle large batches
+        batch_size = 2048
+        all_embeddings = []
+
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i:i + batch_size]
+            response = self.client.embeddings.create(
+                model=self.model_name,
+                input=batch
+            )
+            embeddings = [item.embedding for item in response.data]
+            all_embeddings.extend(embeddings)
+
+        return np.array(all_embeddings)
+
+    def embed_single(self, text: str) -> np.ndarray:
+        """Embed a single text."""
+        return self.embed([text])[0]

--- a/benchmark/models/llm_judges.py
+++ b/benchmark/models/llm_judges.py
@@ -1,0 +1,775 @@
+from abc import ABC
+import json
+import logging
+import re
+
+import openai
+from google import genai
+from google.genai.errors import APIError
+import anthropic
+import together
+from pydantic import BaseModel, TypeAdapter
+
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
+
+
+class LLMJudgeModel(ABC):
+    """Abstract base class for LLM judge models."""
+
+    pass
+
+
+class OpenAIModel(LLMJudgeModel):
+    """Supports any model that conforms to the OpenAI API spec."""
+
+    def __init__(self, model_options: dict):
+        self.model_name = model_options["name"]
+        self.api_key = model_options["api_key"]
+        openai.api_key = self.api_key
+        self.base_url = model_options.get("base_url", None)
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    @retry(
+        retry=retry_if_exception_type(
+            (
+                openai.RateLimitError,
+                openai.APIConnectionError,
+                openai.APIError,
+                ValueError,  # catch our "none‐response" too
+            )
+        ),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+    )
+    def call(self, prompt: str, model_kwargs=None) -> dict:
+        """
+        Call the OpenAI API compatible model with the given prompt.
+
+        Args:
+            prompt (str): The input prompt for the model
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
+
+        Raises:
+            ValueError: If the prompt is empty or model_kwargs is invalid
+            openai.APIError: If there's an API-related error
+            openai.RateLimitError: If rate limit is exceeded
+            openai.APIConnectionError: If there's a network error
+            Exception: For other unexpected errors
+        """
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty")
+
+        model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                **model_kwargs,
+            )
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from OpenAI response")
+
+            return {
+                "response": response.choices[0].message.content,
+                "metadata": metadata
+            }
+        except openai.NotFoundError as e:
+            raise ValueError(
+                f"Invalid OpenAI model name: '{self.model_name}'. "
+                f"Please check the OpenAI documentation for valid model names."
+            ) from e
+        except openai.RateLimitError:
+            raise
+        except openai.APIConnectionError:
+            raise
+        except openai.APIError:
+            raise
+        except Exception as e:
+            raise Exception(f"Unexpected error: {str(e)}") from e
+
+    def parse(self, prompt: str, response_format: BaseModel, model_kwargs=None):
+        """
+        Parse structured output from an OpenAI model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (BaseModel): Parsed response matching the response_format schema
+                - metadata (dict): Token usage information with input_tokens, output_tokens, total_tokens
+
+        Raises:
+            ValueError: If prompt is invalid
+            openai.APIError: If there's an API-related error
+        """
+        model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+
+        try:
+            completion = self.client.beta.chat.completions.parse(
+                model=self.model_name,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant that follows user instructions precisely and provides accurate information.",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                response_format=response_format,
+                **model_kwargs,
+            )
+        except openai.NotFoundError as e:
+            raise ValueError(
+                f"Invalid OpenAI model name: '{self.model_name}'. "
+                f"Please check the OpenAI documentation for valid model names."
+            ) from e
+
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(completion, "usage") and completion.usage:
+            metadata["input_tokens"] = getattr(completion.usage, "prompt_tokens", 0)
+            metadata["output_tokens"] = getattr(completion.usage, "completion_tokens", 0)
+            metadata["total_tokens"] = getattr(completion.usage, "total_tokens", 0)
+        else:
+            logger.warning("Token usage not available from OpenAI parse response")
+
+        message = completion.choices[0].message
+        return {
+            "response": message.parsed,
+            "metadata": metadata
+        }
+
+
+class GeminiModel(LLMJudgeModel):
+    """LLMJudge that supports Google Gemini models."""
+
+    def __init__(self, model_options: dict):
+        self.model_name = model_options["name"]
+        self.client = genai.Client(api_key=model_options["api_key"])
+
+    def _remove_invalid_kwargs(self, model_kwargs) -> dict:
+        if bool(re.match(r"^gemini-2\.5.*", self.model_name, re.IGNORECASE)):
+            model_kwargs = model_kwargs.copy()
+            invalid_kwargs = ["presence_penalty"]
+
+            for kwarg in invalid_kwargs:
+                if kwarg in model_kwargs:
+                    del model_kwargs[kwarg]
+
+        return model_kwargs
+
+    @retry(
+        retry=retry_if_exception_type((APIError, ValueError)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+    )
+    def call(self, prompt: str, model_kwargs=None) -> dict:
+        """
+        Call the Gemini API model with the given prompt.
+
+        Args:
+            prompt (str): The input prompt for the model
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
+
+        Raises:
+            ValueError: If the prompt is empty or model_kwargs is invalid
+            Exception: For API or other unexpected errors
+        """
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty")
+
+        model_kwargs = model_kwargs or {}
+        model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
+
+        try:
+            response = self.client.models.generate_content(
+                model=self.model_name, contents=prompt, config=model_kwargs
+            )
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage_metadata") and response.usage_metadata:
+                metadata["input_tokens"] = getattr(response.usage_metadata, "prompt_token_count", 0)
+                metadata["output_tokens"] = getattr(response.usage_metadata, "candidates_token_count", 0)
+                metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+            else:
+                logger.warning("Token usage not available from Gemini response")
+
+            return {
+                "response": response.text,
+                "metadata": metadata
+            }
+        except APIError as e:
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "model" in error_msg:
+                raise ValueError(
+                    f"Invalid Gemini model name: '{self.model_name}'. "
+                    f"Please check the Google AI documentation for valid model names."
+                ) from e
+            raise
+        except Exception as e:
+            raise Exception(f"Unexpected error: {str(e)}") from e
+
+    def parse(self, prompt: str, response_format: BaseModel, model_kwargs=None):
+        """
+        Parse structured output from a Gemini model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
+        """
+        model_kwargs = model_kwargs or {}
+        model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
+
+        config = {
+            "response_mime_type": "application/json",
+            "response_schema": response_format,
+            **model_kwargs,
+        }
+
+        try:
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                config=config,
+            )
+        except APIError as e:
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "model" in error_msg:
+                raise ValueError(
+                    f"Invalid Gemini model name: '{self.model_name}'. "
+                    f"Please check the Google AI documentation for valid model names."
+                ) from e
+            raise
+
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            metadata["input_tokens"] = getattr(response.usage_metadata, "prompt_token_count", 0)
+            metadata["output_tokens"] = getattr(response.usage_metadata, "candidates_token_count", 0)
+            metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+        else:
+            logger.warning("Token usage not available from Gemini parse response")
+
+        response_json = json.loads(response.text)
+        parsed_response = TypeAdapter(response_format).validate_python(response_json)
+        return {
+            "response": parsed_response,
+            "metadata": metadata
+        }
+
+
+class AnthropicModel(LLMJudgeModel):
+    """LLMJudge that supports Anthropic models."""
+
+    def __init__(self, model_options: dict):
+        self.model_name = model_options["name"]
+        self.client = anthropic.Anthropic(api_key=model_options["api_key"])
+
+    def _remove_invalid_kwargs(self, model_kwargs) -> dict:
+        """
+        Remove kwargs that are not supported by Anthropic's API.
+
+        Anthropic does not support:
+        - presence_penalty, frequency_penalty, seed (OpenAI-specific)
+        - Both temperature AND top_p simultaneously (must choose one)
+
+        When both temperature and top_p are present, we keep temperature
+        and remove top_p, as temperature is more commonly used for
+        deterministic outputs (temperature=0).
+
+        Args:
+            model_kwargs: Dictionary of model parameters
+
+        Returns:
+            Dictionary with invalid parameters removed
+        """
+        model_kwargs = model_kwargs.copy()
+
+        # Remove OpenAI-specific parameters
+        invalid_kwargs = ["presence_penalty", "frequency_penalty", "seed"]
+        for kwarg in invalid_kwargs:
+            if kwarg in model_kwargs:
+                del model_kwargs[kwarg]
+
+        # Handle temperature/top_p conflict
+        # Anthropic doesn't allow both - keep temperature, remove top_p
+        if "temperature" in model_kwargs and "top_p" in model_kwargs:
+            del model_kwargs["top_p"]
+
+        return model_kwargs
+
+    @retry(
+        retry=retry_if_exception_type(
+            (
+                anthropic.InternalServerError,
+                anthropic.APITimeoutError,
+                anthropic.APIConnectionError,
+                ValueError,
+            )
+        ),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+    )
+    def call(self, prompt: str, model_kwargs=None) -> dict:
+        """
+        Call the Anthropic API model with the given prompt.
+
+        Args:
+            prompt (str): The input prompt for the model
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
+
+        Raises:
+            ValueError: If the prompt is empty or model_kwargs is invalid
+            anthropic.InternalServerError: If there's a server-side issue
+            anthropic.APITimeoutError: If the request timeout limit is exceeded
+            anthropic.APIConnectionError: If there's a network error
+            Exception: For API or other unexpected errors
+        """
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty")
+
+        model_kwargs = model_kwargs or {}
+        model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        logger = logging.getLogger(__name__)
+
+        try:
+            max_tokens = None
+            if "max_tokens" in model_kwargs:
+                max_tokens = model_kwargs.pop("max_tokens")
+            else:
+                max_tokens = 16384
+
+            response = self.client.messages.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+                **model_kwargs,
+            )
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "input_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "output_tokens", 0)
+                metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+            else:
+                logger.warning("Token usage not available from Anthropic response")
+
+            return {
+                "response": response.content[0].text,
+                "metadata": metadata
+            }
+        except anthropic.NotFoundError as e:
+            raise ValueError(
+                f"Invalid Anthropic model name: '{self.model_name}'. "
+                f"Please check the Anthropic documentation for valid model names."
+            ) from e
+        except anthropic.InternalServerError:
+            raise
+        except anthropic.APITimeoutError:
+            raise
+        except anthropic.APIConnectionError:
+            raise
+        except Exception as e:
+            raise Exception(f"Unexpected error: {str(e)}") from e
+
+    def parse(self, prompt: str, response_format: BaseModel, model_kwargs=None):
+        """
+        Parse structured output from an Anthropic model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
+        """
+        model_kwargs = model_kwargs or {}
+        model_kwargs = self._remove_invalid_kwargs(model_kwargs)
+        schema = response_format.model_json_schema()
+
+        structured_prompt = f"""{prompt}
+
+Please respond with a JSON object that matches this exact schema:
+{json.dumps(schema, indent=2)}
+
+Return only the JSON object, no other text."""
+
+        max_tokens = None
+        if "max_tokens" in model_kwargs:
+            max_tokens = model_kwargs.pop("max_tokens")
+        else:
+            max_tokens = 16384
+
+        try:
+            response = self.client.messages.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": structured_prompt}],
+                max_tokens=max_tokens,
+                **model_kwargs,
+            )
+        except anthropic.NotFoundError as e:
+            raise ValueError(
+                f"Invalid Anthropic model name: '{self.model_name}'. "
+                f"Please check the Anthropic documentation for valid model names."
+            ) from e
+
+        # Extract token usage
+        logger = logging.getLogger(__name__)
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage") and response.usage:
+            metadata["input_tokens"] = getattr(response.usage, "input_tokens", 0)
+            metadata["output_tokens"] = getattr(response.usage, "output_tokens", 0)
+            metadata["total_tokens"] = metadata["input_tokens"] + metadata["output_tokens"]
+        else:
+            logger.warning("Token usage not available from Anthropic parse response")
+
+        # Validate response structure before parsing
+        if not response.content:
+            raise ValueError(
+                "Anthropic API returned empty content array. "
+                f"Response: {response}"
+            )
+
+        response_text = response.content[0].text
+
+        # Debug logging to capture what Claude actually returned
+        logger.info(f"Anthropic response length: {len(response_text)} chars")
+        logger.info(f"Anthropic response (first 500 chars): {response_text[:500]}")
+
+        # Check if response is empty or whitespace
+        if not response_text or not response_text.strip():
+            raise ValueError(
+                f"Anthropic API returned empty or whitespace-only response. "
+                f"Full response object: {response}"
+            )
+
+        # Strip markdown code fences if present (Claude often wraps JSON in ```json...```)
+        cleaned_text = response_text.strip()
+        if cleaned_text.startswith('```'):
+            # Remove opening fence (```json or just ```)
+            lines = cleaned_text.split('\n')
+            if lines[0].startswith('```'):
+                lines = lines[1:]
+            # Remove closing fence (```)
+            if lines and lines[-1].strip() == '```':
+                lines = lines[:-1]
+            cleaned_text = '\n'.join(lines).strip()
+            logger.info("Stripped markdown code fences from Anthropic response")
+
+        # Try to parse JSON with better error handling
+        try:
+            response_json = json.loads(cleaned_text)
+        except json.JSONDecodeError as e:
+            # Provide detailed error with what was actually returned
+            raise ValueError(
+                f"Failed to parse Anthropic response as JSON. "
+                f"JSONDecodeError: {str(e)}. "
+                f"Original response (first 1000 chars): '{response_text[:1000]}'. "
+                f"Cleaned response (first 1000 chars): '{cleaned_text[:1000]}'. "
+                f"Response text length: {len(response_text)} chars."
+            ) from e
+
+        parsed_response = TypeAdapter(response_format).validate_python(response_json)
+        return {
+            "response": parsed_response,
+            "metadata": metadata
+        }
+
+
+class TogetherModel(LLMJudgeModel):
+    """LLMJudge that supports Together models."""
+
+    def __init__(self, model_options: dict):
+        self.model_name = model_options["name"]
+        self.client = together.Together(api_key=model_options["api_key"])
+
+    @retry(
+        retry=retry_if_exception_type(
+            (
+                together.error.Timeout,
+                together.error.APIConnectionError,
+                together.error.RateLimitError,
+                ValueError,
+            )
+        ),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+    )
+    def call(self, prompt: str, model_kwargs=None) -> dict:
+        """
+        Call the Together API model with the given prompt.
+
+        Args:
+            prompt (str): The input prompt for the model
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response (str): The model's response text
+                - metadata (dict): Token usage and model information
+
+        Raises:
+            ValueError: If the prompt is empty or model_kwargs is invalid
+            together.error.Timeout: If the request timeout limit is exceeded
+            together.error.APIConnectionError: If there's a network error
+            together.error.RateLimitError: If rate limit is exceeded
+            Exception: For API or other unexpected errors
+        """
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty")
+
+        model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                **model_kwargs,
+            )
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from Together response")
+
+            return {
+                "response": response.choices[0].message.content,
+                "metadata": metadata
+            }
+        except together.error.Timeout:
+            raise
+        except together.error.APIConnectionError:
+            raise
+        except together.error.RateLimitError:
+            raise
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "invalid model" in error_msg:
+                raise ValueError(
+                    f"Invalid Together model name: '{self.model_name}'. "
+                    f"Please check the Together AI documentation for valid model names."
+                ) from e
+            raise Exception(f"Unexpected error: {str(e)}") from e
+
+    def parse(self, prompt: str, response_format: BaseModel, model_kwargs=None):
+        """
+        Parse structured output from a Together model according to a Pydantic schema.
+
+        Args:
+            prompt (str): The input prompt
+            response_format (BaseModel): Pydantic model defining the expected response structure
+            model_kwargs (dict, optional): Additional kwargs for the API call
+
+        Returns:
+            dict: Dictionary containing:
+                - response: The parsed response matching the provided schema
+                - metadata (dict): Token usage and model information
+        """
+        model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+
+        # Get the raw schema and flatten it to remove $ref constructs (caused by AutoNuggetizer)
+        schema = response_format.model_json_schema()
+        flattened_schema = self._flatten_schema(schema)
+
+        config = {
+            "type": "json_schema",
+            "schema": flattened_schema,
+        }
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                response_format=config,
+                **model_kwargs,
+            )
+
+            # Extract token usage
+            metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            if hasattr(response, "usage") and response.usage:
+                metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+                metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+                metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+            else:
+                logger.warning("Token usage not available from Together parse response")
+
+            response_json = json.loads(response.choices[0].message.content)
+            parsed_response = TypeAdapter(response_format).validate_python(
+                response_json
+            )
+            return {
+                "response": parsed_response,
+                "metadata": metadata
+            }
+        except Exception as e:
+            error_msg = str(e).lower()
+            # Check for invalid model name error
+            if "not found" in error_msg or "invalid model" in error_msg:
+                raise ValueError(
+                    f"Invalid Together model name: '{self.model_name}'. "
+                    f"Please check the Together AI documentation for valid model names."
+                ) from e
+            # If grammar validation fails, fall back to prompt-based approach like AnthropicModel
+            if "grammar" in error_msg:
+                return self._fallback_parse(prompt, response_format, model_kwargs)
+            raise e
+
+    def _fallback_parse(
+        self, prompt: str, response_format: BaseModel, model_kwargs=None
+    ):
+        """
+        Fallback parsing method that uses prompt-based JSON generation instead of grammar validation.
+        """
+        model_kwargs = model_kwargs or {}
+        logger = logging.getLogger(__name__)
+        schema = response_format.model_json_schema()
+
+        structured_prompt = f"""{prompt}
+
+Please respond with a JSON object that matches this exact schema:
+{json.dumps(schema, indent=2)}
+
+Return only the JSON object, no other text."""
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": structured_prompt}],
+                **model_kwargs,
+            )
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "invalid model" in error_msg:
+                raise ValueError(
+                    f"Invalid Together model name: '{self.model_name}'. "
+                    f"Please check the Together AI documentation for valid model names."
+                ) from e
+            raise
+
+        # Extract token usage
+        metadata = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        if hasattr(response, "usage") and response.usage:
+            metadata["input_tokens"] = getattr(response.usage, "prompt_tokens", 0)
+            metadata["output_tokens"] = getattr(response.usage, "completion_tokens", 0)
+            metadata["total_tokens"] = getattr(response.usage, "total_tokens", 0)
+        else:
+            logger.warning("Token usage not available from Together fallback parse response")
+
+        response_text = response.choices[0].message.content.strip()
+
+        # Extract JSON from response text (in case there's extra text)
+        try:
+            # Try to find JSON object in the response
+            start_idx = response_text.find("{")
+            end_idx = response_text.rfind("}") + 1
+            if start_idx != -1 and end_idx > start_idx:
+                json_str = response_text[start_idx:end_idx]
+                response_json = json.loads(json_str)
+            else:
+                # Fallback: try to parse the entire response as JSON
+                response_json = json.loads(response_text)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Failed to parse JSON from Together response: {response_text}"
+            ) from e
+
+        try:
+            parsed_response = TypeAdapter(response_format).validate_python(
+                response_json
+            )
+            return {
+                "response": parsed_response,
+                "metadata": metadata
+            }
+        except Exception as e:
+            raise ValueError(
+                f"Failed to validate response against schema: {response_json}"
+            ) from e
+
+    def _flatten_schema(self, schema):
+        """
+        Flatten JSON schema by resolving $ref constructs that Together's grammar validator doesn't support.
+        """
+        if not isinstance(schema, dict):
+            return schema
+
+        # Copy the schema to avoid mutating the original
+        flattened = schema.copy()
+
+        # If there are $defs, resolve them inline
+        if "$defs" in schema:
+            defs = schema["$defs"]
+            flattened = self._resolve_refs(flattened, defs)
+            # Remove $defs from the final schema since all refs are resolved
+            flattened.pop("$defs", None)
+
+        return flattened
+
+    def _resolve_refs(self, obj, defs):
+        """
+        Recursively resolve $ref constructs by replacing them with their definitions.
+        """
+        if isinstance(obj, dict):
+            if "$ref" in obj:
+                # Extract the reference path (e.g., "#/$defs/NuggetImportanceValues")
+                ref_path = obj["$ref"]
+                if ref_path.startswith("#/$defs/"):
+                    def_name = ref_path.split("/")[-1]
+                    if def_name in defs:
+                        return self._resolve_refs(defs[def_name], defs)
+                return obj
+            return {k: self._resolve_refs(v, defs) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._resolve_refs(item, defs) for item in obj]
+        return obj


### PR DESCRIPTION
在benchmark下增加了models文件夹有llm和embedding model，metric是两个指标(语义相似度embedding和factual correctness 是llm as judge)的实现。
如果需要计算新加的指标，在原来python -m benchmark.evaluate benchmark_results.json --output my_eval.json --golden加上golden

增加的三个文件都是从open-rag-eval中